### PR TITLE
Fix file decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can also write and read bencodings.
     # read from file
     File.bdecode("a.bencode")           #=> "string"
 
-    file = File.open("a.bencode", "wb")
+    file = File.open("a.bencode", "rb")
     file.bdecode                        #=> "string"
 ```
 

--- a/bencodr.gemspec
+++ b/bencodr.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.description = "This gem provides a way to encode and decode bencode used by the Bit Torrent protocol. Normal ruby objects can be marshalled as bencode and demarshalled back to ruby."
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.add_development_dependency "rspec",   "~> 2.1.0"
+  s.add_development_dependency "rspec",   "~> 2.8.0"
   s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "fuubar",  ">= 0.0.1"
+  s.add_development_dependency "fuubar",  ">= 1.0.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/bencodr/io.rb
+++ b/lib/bencodr/io.rb
@@ -6,20 +6,20 @@ module BEncodr
       def bencode(fd, object)
         open(fd, "wb") {|file| file.bencode(object)}
       end
-      
+
       def bdecode(fd)
         open(fd, "rb") {|file| file.bdecode}
       end
     end
-    
+
     def bencode(object)
       write(Object.bencode(object))
     end
-    
+
     def bdecode
-      Object.bdecode(read.force_encoding('UTF-8'))
+      Object.bdecode(read)
     end
-    
+
     def self.included(base)
       base.extend ClassMethods
     end

--- a/spec/bencodr/io_spec.rb
+++ b/spec/bencodr/io_spec.rb
@@ -1,35 +1,62 @@
 # encoding: UTF-8
 require "spec_helper"
+require 'tempfile'
 
 describe File do
   before :all do
-    @path = "tmp"
-    Dir.mkdir(@path) unless File.exists? @path
     BEncodr.include!
   end
 
-  before :each do
-    @file = File.join(@path, 'test.bencodr')
-    @object = "string"
-    File.bencode(@file, @object)
-  end
-  
-  describe "#bencode" do
-    subject{ File }
-    
-    it{ File.should exist(@file) }
-  end
-  
-  describe "#bdecode" do
-    subject{ File }
-    it{ should bdecode(@file).to(@object) }
-  end
-  
-  after :each do
-    File.delete(@file)
+  let(:file)   { Tempfile.new('test.bencodr') }
+  let(:object) { "string" }
+
+  describe ".bencode" do
+    it "should encode object to file" do
+      File.bencode(file, object)
+      file.rewind
+      file.read.should == "6:string"
+    end
   end
 
-  after :all do
-    Dir.delete(@path) if File.exists? @path
+  describe "#bencode" do
+    it "should encode object to file" do
+      file.bencode(object)
+      file.rewind
+      file.read.should == "6:string"
+    end
+  end
+
+  context "decode" do
+    let(:sample_path) { 'spec/samples/bencodr.torrent' }
+
+    before do
+      file.bencode(object)
+      file.rewind
+    end
+
+    describe ".bdecode" do
+      subject{ File }
+
+      it "should decode object from file" do
+        should bdecode(file).to(object)
+      end
+
+      it "should decode sample file without error" do
+        expect{ File.bdecode(sample_path) }.to_not raise_error
+      end
+    end
+
+    describe "#bdecode" do
+      subject{ file }
+
+      it "should decode object from file" do
+        should bdecode_to(object)
+      end
+
+      it "should decode sample file without error" do
+        f = File.open(sample_path, 'rb')
+        expect{ f.bdecode }.to_not raise_error
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'fuubar'
 require 'custom_matchers'
 require 'shared_examples'
 
-Rspec.configure do |c|
+RSpec.configure do |c|
   c.formatter = Fuubar
   c.color_enabled = true
 end


### PR DESCRIPTION
Fix `ArgumentError: invalid byte sequence in UTF-8` when decoding real files in ruby-1.9.2p312:

``` ruby
File.bdecode('bencode.txt')
# or
file = File.open('bencode.txt', 'rb')
file.bdecode
```

Add necessary tests.
Remove `force_encoding('UTF-8')` from `File#bdecode`.
Fix minor error in readme file.
Also had update gem dependencies.
